### PR TITLE
fix(autonotifier): use a PAT token to get `read:org` permission for mentioning teams in comments

### DIFF
--- a/.github/workflows/autonotifer.yaml
+++ b/.github/workflows/autonotifer.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: jenschelkopf/issue-label-notification-action@1.3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTONOTIFIER_GITHUB_TOKEN }}
           recipients: |
             crowdin=@jenkins-infra/crowdin-admins
             helpdesk=@lemeurherve


### PR DESCRIPTION
As [there isn't any permission related to the org for GHA](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions), I've generated a PAT from my account in order to give `read:org` rights to the autonotifier GitHub Action so it can mention teams in comments .

<img width="873" alt="image" src="https://user-images.githubusercontent.com/91831478/173801030-a6ec297c-8ec7-445b-81fa-90ae31388c3c.png">

Follow-up of https://github.com/jenkins-infra/helpdesk/pull/2992