### PR TITLE
chore: Restore services list in alphabetical order

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1-report-issue.yml
@@ -44,15 +44,15 @@ body:
         - "GitHub"
         - "Helpdesk"
         - "Incrementals"
+        - "IRC"
         - "Jira"
         - "LDAP"
         - "Mailing lists"
-        - "IRC"
+        - "Oracle"
         - "pkg.jenkins.io"
         - "plugins.jenkins.io"
         - "VPN"
         - "Update center"
-        - "Oracle"
         - "Other"
     validations:
       required: true


### PR DESCRIPTION
Title says all, recent additions made the list become out of order, which is kinda inconvenient.