### PR TITLE
fix: use github-app-token action instead of a PAT

### DIFF
--- a/.github/workflows/autonotifer.yaml
+++ b/.github/workflows/autonotifer.yaml
@@ -10,9 +10,15 @@ jobs:
   autonotifier:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.INFRA_GITHUB_APP_ID }}
+          private_key: ${{ secrets.INFRA_GITHUB_APP_PRIVATE_KEY }}
       - uses: jenschelkopf/issue-label-notification-action@1.3
         with:
-          token: ${{ secrets.AUTONOTIFIER_GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           recipients: |
             crowdin=@jenkins-infra/crowdin-admins
             helpdesk=@lemeurherve


### PR DESCRIPTION
https://github.com/marketplace/actions/github-app-token

Fixes comments posted by me instead of `github-action`

Suggested by @timja here: https://github.com/jenkins-infra/helpdesk/pull/2993#issuecomment-1156587400

Follow-up of https://github.com/jenkins-infra/helpdesk/pull/2993