### PR TITLE
fix: tokens for actions

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -12,7 +12,15 @@ jobs:
         with:
           template-path: .github/ISSUE_TEMPLATE/1-report-issue.yml
       - run: echo "ISSUE_LABELS=$(echo '${{ fromJSON(steps.issue-parser.outputs.jsonString).services }}' | tr '[:upper:]' '[:lower:]' | sed 's/"//g' | sed 's/ //g')" >> $GITHUB_ENV
-      - uses: andymckay/labeler@master
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
         with:
+          app_id: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_ID }}
+          private_key: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_PRIVATE_KEY }}
+      - uses: andymckay/labeler@master
+        id: autolabeler
+        with:
+          repo-token: ${{ steps.generate_token.outputs.token }}
           add-labels: "${{ env.ISSUE_LABELS }}"
           remove-labels: "other"

--- a/.github/workflows/autonotifer.yaml
+++ b/.github/workflows/autonotifer.yaml
@@ -14,8 +14,8 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ secrets.INFRA_GITHUB_APP_ID }}
-          private_key: ${{ secrets.INFRA_GITHUB_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_ID }}
+          private_key: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_PRIVATE_KEY }}
       - uses: jenschelkopf/issue-label-notification-action@1.3
         with:
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/autonotifer.yaml
+++ b/.github/workflows/autonotifer.yaml
@@ -2,10 +2,10 @@ name: Notify users based on issue labels
 on:
   issues:
     types: [labeled]
-  workflow_run:
-    workflows: ["Auto Labeler"]
-    types:
-      - completed
+#  workflow_run:
+#    workflows: ["Auto Labeler"]
+#    types:
+#      - completed
 jobs:
   autonotifier:
     runs-on: ubuntu-latest
@@ -14,8 +14,8 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_ID }}
-          private_key: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.INFRA_GITHUB_APP_ID }}
+          private_key: ${{ secrets.INFRA_GITHUB_APP_PRIVATE_KEY }}
       - uses: jenschelkopf/issue-label-notification-action@1.3
         with:
           token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Removing workflow_run as [it doesn't seem to work](https://github.com/jenkins-infra/helpdesk/runs/6907125072?check_suite_focus=true), the autonotifier action can't determine the issue number concerned.