### PR TITLE
fix: issues similarity comment only on open issues

### DIFF
--- a/.github/workflows/issues-similarity.yml
+++ b/.github/workflows/issues-similarity.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   similarity-analysis:
     runs-on: ubuntu-latest
+    if: github.event.issue.state == 'open'
     steps:
       - name: analysis
         uses: actions-cool/issues-similarity-analysis@v1.0.0


### PR DESCRIPTION
As noted [here](https://github.com/jenkins-infra/helpdesk/issues/2664#issuecomment-1167810201) by @timja this GHA shouldn't comment on edited issues if they are closed.