### PR TITLE
chore: search similar issues up to 2 years ago

### DIFF
--- a/.github/workflows/issues-similarity.yml
+++ b/.github/workflows/issues-similarity.yml
@@ -16,3 +16,4 @@ jobs:
           comment-title: "### Take a look at these similar issues to see if there isn't already a response to your problem:"
           comment-body: '${index}. ${similarity} #${number}'
           show-footer: false
+          since-days: 730


### PR DESCRIPTION
Compared to the issues history, searching similar issues in less than the last quarter seems too short.
(default value: 100 days, as seen in the action logs)
I'm proposing 2 years, WDYT?