### PR TITLE
fix(infra-meeting-release): exclude 'not planned' closed issues from the 'Done' ones

### DIFF
--- a/.github/workflows/infra-meeting-release.yaml
+++ b/.github/workflows/infra-meeting-release.yaml
@@ -40,13 +40,24 @@ jobs:
           result-encoding: string
           script: |
             const getMilestoneAsMarkdown = async function(milestone, milestoneName, issuesState) {
-              const opts = github.rest.issues.listForRepo.endpoint.merge({
-                ...context.issue,
-                milestone,
-                state: issuesState,
-                sort: 'updated',
-                per_page: 100,
-              })
+              if (issuesState == 'closed') {
+                const opts = github.rest.issues.listForRepo.endpoint.merge({
+                  ...context.issue,
+                  milestone,
+                  state: issuesState,
+                  reason: 'complete',
+                  sort: 'updated',
+                  per_page: 100,
+                })
+              } else {
+                const opts = github.rest.issues.listForRepo.endpoint.merge({
+                  ...context.issue,
+                  milestone,
+                  state: issuesState,
+                  sort: 'updated',
+                  per_page: 100,
+                })
+              }
               const issues = await github.paginate(opts)
 
               let markdown = ''


### PR DESCRIPTION
Ex of closed issue to exclude as closed for "not planned" reason: https://github.com/jenkins-infra/helpdesk/issues/3106
