### PR TITLE
chore: Swap GH permission level

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-github-permissions.yml
+++ b/.github/ISSUE_TEMPLATE/2-github-permissions.yml
@@ -28,8 +28,8 @@ body:
       label: Permission level
       options:
         - "Read"
-        - "Write"
         - "Triage"
+        - "Write"
         - "Maintain"
         - "Admin"
     validations:


### PR DESCRIPTION
If we're going by hierarchy, "Triage" is lower than "Write".

![Screenshot 2022-10-19 at 16 45 43](https://user-images.githubusercontent.com/13383509/196724297-a0a64c2a-fbfc-44c7-83d1-21dc1dd97afe.png)
