### PR TITLE
feat(infra-meeting-notes): add a "copy" button to the generated markdown

### DIFF
--- a/.github/workflows/infra-meeting-release.yaml
+++ b/.github/workflows/infra-meeting-release.yaml
@@ -86,13 +86,13 @@ jobs:
             next = await getMilestoneAsMarkdown(context.payload.inputs.next_milestone_id, context.payload.inputs.next_milestone_name, 'open')
 
             return `Markdown for the infra team sync meeting notes preparation:
-            <pre>
+            <pre><code>
             ${done}
 
             ${wip}
 
             ${next}
-            </pre>
+            </code></pre>
 
             <details><summary>Preview:</summary>
 


### PR DESCRIPTION
Add a "Copy" button on the top right corner of the generated markdown block:

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/91831478/203434165-495037ce-1af8-4604-a3fd-e240f902d612.png">
