### PR TITLE
chore: test ratchet to pin GitHub Actions with SHA-1 (#3404

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -6,19 +6,19 @@ jobs:
   autolabeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: stefanbuck/github-issue-parser@v3
+      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # ratchet:actions/checkout@v2.6.0
+      - uses: stefanbuck/github-issue-parser@26aa569a236774fa15b73a965595c0a0ac8ccf41 # ratchet:stefanbuck/github-issue-parser@v3
         id: issue-parser
         with:
           template-path: .github/ISSUE_TEMPLATE/1-report-issue.yml
       - run: echo "ISSUE_LABELS=$(echo '${{ fromJSON(steps.issue-parser.outputs.jsonString).services }}' | tr '[:upper:]' '[:lower:]' | sed 's/"//g' | sed 's/ //g')" >> $GITHUB_ENV
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # ratchet:tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_ID }}
           private_key: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_PRIVATE_KEY }}
-      - uses: andymckay/labeler@master
+      - uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260 # ratchet:andymckay/labeler@master
         id: autolabeler
         with:
           repo-token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
With action/checkout on a previous version to see how/if dependabot will update the corresponding comment.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3402