### PR TITLE
Pin actions/checkout to v3

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -6,7 +6,7 @@ jobs:
   autolabeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.1
+      - uses: actions/checkout@v3
       - uses: stefanbuck/github-issue-parser@26aa569a236774fa15b73a965595c0a0ac8ccf41 # v3
         id: issue-parser
         with:


### PR DESCRIPTION
I doubt we care about minor versions of this dependency in this repository.

Reduces all this noise:
https://github.com/jenkins-infra/helpdesk/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+bump+actions%2Fcheckout