### PR TITLE
chore: add `contributors.jenkins.io` service in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1-report-issue.yml
@@ -38,6 +38,7 @@ body:
         - "release.ci.jenkins.io"
         - "trusted.ci.jenkins.io"
         - "weekly.ci.jenkins.io"
+        - "contributors.jenkins.io"
         - "Crowdin"
         - "Datadog"
         - "DigitalOcean"


### PR DESCRIPTION
This PR adds `contributors.jenkins.io` service in issue template.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3809#issuecomment-1822357561