### PR TITLE
chore: add `issue-redirect.jenkins.io` service

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1-report-issue.yml
@@ -50,6 +50,7 @@ body:
         - "Helpdesk"
         - "Incrementals"
         - "IRC"
+        - "issue-redirect.jenkins.io"
         - "jenkins.io"
         - "Jira"
         - "LDAP"


### PR DESCRIPTION
This PR adds `issue-redirect.jenkins.io` service.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4889