### PR TITLE
feat(GHA/autolabeler) replace deprecated `tibdex/github-app-token` action by `actions/create-github-app-token`

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -17,10 +17,11 @@ jobs:
         run: echo "svc_labels=${SERVICES// /}" >> "$GITHUB_ENV"
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        # uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         with:
-          app_id: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_ID }}
-          private_key: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_PRIVATE_KEY }}
+          client-id: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_ID }}
+          private-key: ${{ secrets.JENKINS_INFRA_HELPDESK_APP_PRIVATE_KEY }}
       - run: gh issue edit "$NUMBER" --add-label "$LABELS" --remove-label "$RM_LABELS"
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
- `tibdex/github-app-token` action is deprecated and recommends `actions/create-github-app-token`
- NodeJS 20 won't be supported soon in GHA (ref. https://github.com/jenkins-infra/helpdesk/issues/5080)