### PR TITLE
fix(GH/issues) disable blank issues except for helpdesk maintainers/writers/admins

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: 💬 Community forum
     url: https://community.jenkins.io/


### PR DESCRIPTION
We missed a few issues in the past months which weren't labeled with `triage` by default.

One of the compensating measures is to disable the ability to create "blank" issues which is the goal of this change.

As per the GitHub documentation (https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) the users with `write`/`maintain` or `admin` permissions will still be able to create blank issues but not "normal" users.

This is OK: I need and other infra admin also need blank issue templates. But we are responsible for properly labeling our "blank" issues.