### PR TITLE
fix(gha/autolabeler): remove parenthesis content

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: "Trim services list using only shell variable internal (no subshell to avoid injection!)"
         env:
           SERVICES: ${{ steps.issue-parser.outputs.issueparser_services }}
-        run: echo "svc_labels=${SERVICES// /}" >> "$GITHUB_ENV"
+        run: tmp=${SERVICES%% (*}; echo "svc_labels=${tmp// /}" >> "$GITHUB_ENV"
       - name: Generate token
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3


### PR DESCRIPTION
This change fixes the autolabeler GHA, failing when selecting a service including parenthesis.

This also makes the autolabeler to use the same labels as the existing ones cf https://github.com/jenkins-infra/helpdesk/pull/5150#issuecomment-4576855925.

Fixup of:
- #5150 

### Testing done

```bash
$ export TESTING="accounts (accounts.jenkins.io)"
$ bash -c 'tmp=${SERVICES%% (*}; echo "svc_labels=${tmp// /}"'
svc_labels=mailinglist
```